### PR TITLE
Fix `getFromTypeIndex` return type in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ static getFromTypeIndex(webId: string, rdfClass: string, fetch: any, isPrivate: 
 
 **Returns:**
 
-Promise&lt;string\[\]&gt;
+Promise&lt;{ instances: string\[\] }&gt;
 
 
 


### PR DESCRIPTION
See https://github.com/pondersource/solid-typeindex-support/blob/6516d424ebe0aaa7101de960ce10f8169405fa0a/src/TypeIndexHelper.ts#L172